### PR TITLE
Add savings goal tracking

### DIFF
--- a/BudgetSaver/AppShell.xaml
+++ b/BudgetSaver/AppShell.xaml
@@ -23,5 +23,9 @@
         Title="History"
         ContentTemplate="{DataTemplate views:HistoryPage}"
         Route="HistoryPage" />
+    <ShellContent
+        Title="Savings Goal"
+        ContentTemplate="{DataTemplate views:SavingsGoalPage}"
+        Route="SavingsGoalPage" />
 
 </Shell>

--- a/BudgetSaver/Models/SavingsGoal.cs
+++ b/BudgetSaver/Models/SavingsGoal.cs
@@ -1,0 +1,8 @@
+namespace BudgetSaver.Models;
+
+public class SavingsGoal
+{
+    public int Id { get; set; }
+    public decimal TargetAmount { get; set; }
+    public decimal SavedAmount { get; set; }
+}

--- a/BudgetSaver/ViewModels/DashboardViewModel.cs
+++ b/BudgetSaver/ViewModels/DashboardViewModel.cs
@@ -1,9 +1,39 @@
 using System.Collections.ObjectModel;
 using BudgetSaver.Models;
+using Microsoft.Maui.Storage;
 
 namespace BudgetSaver.ViewModels;
 
 public class DashboardViewModel : BaseViewModel
 {
     public ObservableCollection<Event> UpcomingEvents { get; } = new();
+
+    private decimal targetAmount;
+    private decimal savedAmount;
+
+    public decimal TargetAmount
+    {
+        get => targetAmount;
+        set => SetProperty(ref targetAmount, value);
+    }
+
+    public decimal SavedAmount
+    {
+        get => savedAmount;
+        set => SetProperty(ref savedAmount, value);
+    }
+
+    public double GoalProgress => TargetAmount == 0 ? 0 : (double)(SavedAmount / TargetAmount);
+
+    public DashboardViewModel()
+    {
+        LoadGoal();
+    }
+
+    public void LoadGoal()
+    {
+        TargetAmount = Preferences.Get("goal_target", 0m);
+        SavedAmount = Preferences.Get("goal_saved", 0m);
+        OnPropertyChanged(nameof(GoalProgress));
+    }
 }

--- a/BudgetSaver/ViewModels/SavingsGoalViewModel.cs
+++ b/BudgetSaver/ViewModels/SavingsGoalViewModel.cs
@@ -1,0 +1,37 @@
+using System.Windows.Input;
+using Microsoft.Maui.Storage;
+
+namespace BudgetSaver.ViewModels;
+
+public class SavingsGoalViewModel : BaseViewModel
+{
+    private decimal targetAmount;
+    private decimal savedAmount;
+
+    public decimal TargetAmount
+    {
+        get => targetAmount;
+        set => SetProperty(ref targetAmount, value);
+    }
+
+    public decimal SavedAmount
+    {
+        get => savedAmount;
+        set => SetProperty(ref savedAmount, value);
+    }
+
+    public ICommand SaveCommand { get; }
+
+    public SavingsGoalViewModel()
+    {
+        targetAmount = Preferences.Get("goal_target", 0m);
+        savedAmount = Preferences.Get("goal_saved", 0m);
+        SaveCommand = new Command(OnSave);
+    }
+
+    private void OnSave()
+    {
+        Preferences.Set("goal_target", TargetAmount);
+        Preferences.Set("goal_saved", SavedAmount);
+    }
+}

--- a/BudgetSaver/Views/DashboardPage.xaml
+++ b/BudgetSaver/Views/DashboardPage.xaml
@@ -3,11 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="BudgetSaver.Views.DashboardPage"
              Title="Dashboard">
-    <CollectionView ItemsSource="{Binding UpcomingEvents}">
-        <CollectionView.ItemTemplate>
-            <DataTemplate>
-                <TextCell Text="{Binding Name}" Detail="{Binding Date}" />
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-    </CollectionView>
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Savings Progress" />
+        <ProgressBar Progress="{Binding GoalProgress}" />
+        <Label Text="{Binding SavedAmount, StringFormat='Saved: {0:C}'}" />
+        <Label Text="{Binding TargetAmount, StringFormat='Goal: {0:C}'}" />
+        <CollectionView ItemsSource="{Binding UpcomingEvents}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <TextCell Text="{Binding Name}" Detail="{Binding Date}" />
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
 </ContentPage>

--- a/BudgetSaver/Views/DashboardPage.xaml.cs
+++ b/BudgetSaver/Views/DashboardPage.xaml.cs
@@ -2,9 +2,18 @@ namespace BudgetSaver.Views;
 
 public partial class DashboardPage : ContentPage
 {
+    private readonly BudgetSaver.ViewModels.DashboardViewModel viewModel;
+
     public DashboardPage()
     {
         InitializeComponent();
-        BindingContext = new BudgetSaver.ViewModels.DashboardViewModel();
+        viewModel = new BudgetSaver.ViewModels.DashboardViewModel();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        viewModel.LoadGoal();
     }
 }

--- a/BudgetSaver/Views/SavingsGoalPage.xaml
+++ b/BudgetSaver/Views/SavingsGoalPage.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="BudgetSaver.Views.SavingsGoalPage"
+             Title="Savings Goal">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Entry Placeholder="Target Amount" Keyboard="Numeric" Text="{Binding TargetAmount}" />
+        <Entry Placeholder="Saved Amount" Keyboard="Numeric" Text="{Binding SavedAmount}" />
+        <Button Text="Save" Command="{Binding SaveCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/BudgetSaver/Views/SavingsGoalPage.xaml.cs
+++ b/BudgetSaver/Views/SavingsGoalPage.xaml.cs
@@ -1,0 +1,10 @@
+namespace BudgetSaver.Views;
+
+public partial class SavingsGoalPage : ContentPage
+{
+    public SavingsGoalPage()
+    {
+        InitializeComponent();
+        BindingContext = new BudgetSaver.ViewModels.SavingsGoalViewModel();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # BudgetSaver
 
 This repository contains a minimal .NET MAUI project generated with `dotnet new maui`.
+
+## Features
+
+- Dashboard with overview of upcoming events and savings progress.
+- Add events and view history.
+- Set a savings goal and track your progress on the dashboard.


### PR DESCRIPTION
## Summary
- create new `SavingsGoal` model and view model
- add `SavingsGoalPage` for setting goal information
- display goal progress in `DashboardPage`
- hook up refresh logic for dashboard
- document new feature in README

## Testing
- `dotnet workload restore`
- `dotnet build -v:q` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6842cdea528c832ca749c9f3a85c24d7