### PR TITLE
Add SQLite EF Core context and service

### DIFF
--- a/BudgetSaver/BudgetSaver.csproj
+++ b/BudgetSaver/BudgetSaver.csproj
@@ -30,8 +30,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<!-- App Icon -->
+  <ItemGroup>
+    <!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
@@ -42,7 +42,11 @@
 		<MauiImage Update="Resources\Images\dotnet_bot.svg" BaseSize="168,208" />
 
                 <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
+    <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
+  </ItemGroup>
 
 </Project>

--- a/BudgetSaver/Data/SavingsDbContext.cs
+++ b/BudgetSaver/Data/SavingsDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using BudgetSaver.Models;
+
+namespace BudgetSaver.Data;
+
+public class SavingsDbContext : DbContext
+{
+    public SavingsDbContext(DbContextOptions<SavingsDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<SavingsEvent> SavingsEvents => Set<SavingsEvent>();
+}

--- a/BudgetSaver/MauiProgram.cs
+++ b/BudgetSaver/MauiProgram.cs
@@ -1,13 +1,24 @@
-﻿namespace BudgetSaver;
+using System.IO;
+using BudgetSaver.Data;
+using BudgetSaver.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Maui.Storage;
+
+namespace BudgetSaver;
 
 public static class MauiProgram
 {
-        public static MauiApp CreateMauiApp()
-        {
-            var builder = MauiApp.CreateBuilder();
-            builder
-                .UseMauiApp<App>();
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
 
-            return builder.Build();
-        }
+        var dbPath = Path.Combine(FileSystem.AppDataDirectory, "savings.db");
+        builder.Services.AddDbContext<SavingsDbContext>(options =>
+            options.UseSqlite($"Filename={dbPath}"));
+        builder.Services.AddTransient<SavingsEventService>();
+
+        return builder.Build();
+    }
 }

--- a/BudgetSaver/Models/SavingsEvent.cs
+++ b/BudgetSaver/Models/SavingsEvent.cs
@@ -1,0 +1,9 @@
+namespace BudgetSaver.Models;
+
+public class SavingsEvent
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/BudgetSaver/Services/SavingsEventService.cs
+++ b/BudgetSaver/Services/SavingsEventService.cs
@@ -1,0 +1,43 @@
+using BudgetSaver.Data;
+using BudgetSaver.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BudgetSaver.Services;
+
+public class SavingsEventService
+{
+    private readonly SavingsDbContext _context;
+
+    public SavingsEventService(SavingsDbContext context)
+    {
+        _context = context;
+        _context.Database.EnsureCreated();
+    }
+
+    public async Task AddEventAsync(SavingsEvent savingsEvent)
+    {
+        _context.SavingsEvents.Add(savingsEvent);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<List<SavingsEvent>> GetEventsAsync()
+    {
+        return await _context.SavingsEvents.AsNoTracking().ToListAsync();
+    }
+
+    public async Task UpdateEventAsync(SavingsEvent savingsEvent)
+    {
+        _context.SavingsEvents.Update(savingsEvent);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteEventAsync(int id)
+    {
+        var entity = await _context.SavingsEvents.FindAsync(id);
+        if (entity != null)
+        {
+            _context.SavingsEvents.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EF Core SQLite package to csproj
- add `SavingsEvent` model and `SavingsDbContext`
- implement `SavingsEventService` with CRUD methods
- register context and service in `MauiProgram`

## Testing
- `dotnet build BudgetSaver/BudgetSaver.csproj -c Release` *(fails: workloads missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842cde702d4832cb85b222897813755